### PR TITLE
Fix for fatal ReferenceError

### DIFF
--- a/lib/protocol/Protocol.js
+++ b/lib/protocol/Protocol.js
@@ -76,6 +76,8 @@ Protocol.prototype.exec = function(command, cb) {
 };
 
 Protocol.prototype.request = function(content, type, id) {
+    var self = this;
+    
     var id = id || this.getNextPacketId();
     log('Sending packet', id);
     this.connection.write(new Request( {


### PR DESCRIPTION
If the RCON connection runs into an error while writing to the socket, it will hit a fatal ReferenceError saying that `self` is not defined. This is because the variable `self` was not set to `this` in the `request` function like it was within the other functions.
