### PR TITLE
Prevent Uncaught Connection Exceptions

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -33,6 +33,7 @@ module.exports = address => {
                 port: port
             }, () => {
                 connection.removeListener('error', errorHandler);
+                connection.on('error', _errorHandler);
                 resolve(connection);
             });
 
@@ -58,30 +59,36 @@ module.exports = address => {
         });
     }
 
+    function _errorHandler(err) {
+        console.error(err);
+    }
+
     function _disconnectHandler() {
         connection = undefined;
     }
 
     function getData(cbSync) {
         return new Promise((resolve, reject) => {
+            connection.removeListener('error', _errorHandler);
             connection.on('error', errorHandler);
             connection.on('data', dataHandler);
 
             function dataHandler(data) {
                 if (!cbSync(data)) {
-                    removeListeners();
+                    resetListeners();
                     resolve(data);
                 }
             }
 
             function errorHandler(err) {
-                removeListeners();
+                resetListeners();
                 reject(err);
             }
 
-            function removeListeners() {
+            function resetListeners() {
                 connection.removeListener('error', errorHandler);
                 connection.removeListener('data', dataHandler);
+                connection.on('error', _errorHandler);
             }
         });
     }


### PR DESCRIPTION
When a connection is not receiving data via the `getData` function, there is no handler attached to the `error` event, which causes any connection error (like the connection being reset) to be thrown.

This PR adds a simple handler that just logs the error to the console.
